### PR TITLE
Add GitHub Actions for Instruqt CLI

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -1,0 +1,56 @@
+name: Test Actions
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test setup action
+        uses: ./setup
+      - name: Verify CLI is installed
+        run: |
+          instruqt version
+          which instruqt
+
+  test-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Instruqt CLI
+        uses: ./setup
+      - name: Clone lab-examples for testing
+        run: |
+          git clone https://github.com/instruqt/lab-examples.git
+      - name: Test validate action - success case
+        uses: ./validate
+        with:
+          path: ./lab-examples/minimal
+      - name: Test validate action - with fail-on-error false
+        uses: ./validate
+        with:
+          path: ./non-existent-lab
+          fail-on-error: false
+        continue-on-error: true
+
+  test-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lab: [minimal, demo]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Instruqt CLI
+        uses: ./setup
+      - name: Clone lab-examples for testing
+        run: |
+          git clone https://github.com/instruqt/lab-examples.git
+      - name: Validate lab
+        uses: ./validate
+        with:
+          path: ./lab-examples/${{ matrix.lab }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
 # Instruqt CLI
 
 This repository contains the releases of the Instruqt commandline interface.
+
+## GitHub Actions
+
+This repository also provides GitHub Actions for using the Instruqt CLI in CI/CD workflows:
+
+### Setup Action
+
+Installs and caches the Instruqt CLI:
+
+```yaml
+- uses: instruqt/cli/setup@v1
+```
+
+See [setup/README.md](setup/README.md) for detailed documentation.
+
+### Validate Action
+
+Validates Instruqt lab configurations:
+
+```yaml
+- uses: instruqt/cli/validate@v1
+  with:
+    path: ./path/to/lab
+```
+
+See [validate/README.md](validate/README.md) for detailed documentation.
+
+### Example Workflow
+
+See [example-workflow.yml](example-workflow.yml) for a complete example of validating multiple labs in a GitHub Actions workflow.

--- a/example-workflow.yml
+++ b/example-workflow.yml
@@ -1,0 +1,54 @@
+# Example GitHub Actions workflow for validating Instruqt labs
+# Save this as .github/workflows/validate-labs.yml in your repository
+
+name: Validate Labs
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lab:
+          - ./lab-1
+          - ./lab-2
+          - ./lab-3
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Instruqt CLI
+        uses: instruqt/cli/setup@v1
+      
+      - name: Validate lab
+        uses: instruqt/cli/validate@v1
+        with:
+          path: ${{ matrix.lab }}
+
+  # Alternative: validate all labs in sequence
+  validate-sequential:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Instruqt CLI
+        uses: instruqt/cli/setup@v1
+      
+      - name: Validate lab 1
+        uses: instruqt/cli/validate@v1
+        with:
+          path: ./lab-1
+      
+      - name: Validate lab 2
+        uses: instruqt/cli/validate@v1
+        with:
+          path: ./lab-2
+      
+      - name: Validate lab 3
+        uses: instruqt/cli/validate@v1
+        with:
+          path: ./lab-3

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,0 +1,51 @@
+# Setup Instruqt CLI Action
+
+This action installs and caches the Instruqt CLI for use in GitHub Actions workflows.
+
+## Inputs
+
+### `version`
+
+**Optional** The version of Instruqt CLI to install. Default: `latest`.
+
+## Outputs
+
+### `version`
+
+The version of the Instruqt CLI that was installed.
+
+## Example usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: instruqt/cli/setup@v1
+  - uses: instruqt/cli/validate@v1
+    with:
+      path: ./path/to/lab
+```
+
+## Advanced usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: instruqt/cli/setup@v1
+    with:
+      version: '2287-00a1200'
+  - uses: instruqt/cli/validate@v1
+    with:
+      path: ./lab-1
+  - uses: instruqt/cli/validate@v1
+    with:
+      path: ./lab-2
+```
+
+## Platform Support
+
+This action supports:
+- Linux (ubuntu runners)
+- macOS (macos runners, both Intel and Apple Silicon)
+- Windows (windows runners)
+
+The CLI binary is cached to improve performance across workflow runs.

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -1,0 +1,117 @@
+name: 'Setup Instruqt CLI'
+description: 'Install and cache the Instruqt CLI for use in workflows'
+author: 'Instruqt'
+
+inputs:
+  version:
+    description: 'Instruqt CLI version to install'
+    required: false
+    default: 'latest'
+
+outputs:
+  version:
+    description: 'Installed Instruqt CLI version'
+    value: ${{ steps.install.outputs.version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Determine platform and architecture
+      id: platform
+      shell: bash
+      run: |
+        case "${{ runner.os }}" in
+          Linux)
+            echo "platform=linux" >> $GITHUB_OUTPUT
+            ;;
+          macOS)
+            if [[ "${{ runner.arch }}" == "ARM64" ]]; then
+              echo "platform=darwin-arm64" >> $GITHUB_OUTPUT
+            else
+              echo "platform=darwin-amd64" >> $GITHUB_OUTPUT
+            fi
+            ;;
+          Windows)
+            echo "platform=windows" >> $GITHUB_OUTPUT
+            ;;
+          *)
+            echo "::error::Unsupported platform: ${{ runner.os }}"
+            exit 1
+            ;;
+        esac
+
+    - name: Cache Instruqt CLI
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/bin/instruqt
+        key: instruqt-cli-${{ inputs.version }}-${{ steps.platform.outputs.platform }}
+        restore-keys: |
+          instruqt-cli-${{ inputs.version }}-
+          instruqt-cli-
+
+    - name: Install Instruqt CLI
+      id: install
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        PLATFORM: ${{ steps.platform.outputs.platform }}
+      run: |
+        # Determine download URL
+        if [[ "$VERSION" == "latest" ]]; then
+          if [[ "$PLATFORM" == "linux" ]]; then
+            download_url="https://github.com/instruqt/cli/releases/latest/download/instruqt-linux.zip"
+          elif [[ "$PLATFORM" == "darwin-amd64" ]]; then
+            download_url="https://github.com/instruqt/cli/releases/latest/download/instruqt-darwin-amd64.zip"
+          elif [[ "$PLATFORM" == "darwin-arm64" ]]; then
+            download_url="https://github.com/instruqt/cli/releases/latest/download/instruqt-darwin-arm64.zip"
+          elif [[ "$PLATFORM" == "windows" ]]; then
+            download_url="https://github.com/instruqt/cli/releases/latest/download/instruqt-windows.zip"
+          fi
+        else
+          if [[ "$PLATFORM" == "linux" ]]; then
+            download_url="https://github.com/instruqt/cli/releases/download/${VERSION}/instruqt-linux.zip"
+          elif [[ "$PLATFORM" == "darwin-amd64" ]]; then
+            download_url="https://github.com/instruqt/cli/releases/download/${VERSION}/instruqt-darwin-amd64.zip"
+          elif [[ "$PLATFORM" == "darwin-arm64" ]]; then
+            download_url="https://github.com/instruqt/cli/releases/download/${VERSION}/instruqt-darwin-arm64.zip"
+          elif [[ "$PLATFORM" == "windows" ]]; then
+            download_url="https://github.com/instruqt/cli/releases/download/${VERSION}/instruqt-windows.zip"
+          fi
+        fi
+        
+        echo "Downloading from: $download_url"
+        
+        # Download and extract
+        curl -L -o instruqt.zip "$download_url"
+        unzip -q instruqt.zip
+        
+        # Install to local bin
+        mkdir -p ~/.local/bin
+        if [[ "$PLATFORM" == "windows" ]]; then
+          mv instruqt.exe ~/.local/bin/
+        else
+          mv instruqt ~/.local/bin/
+          chmod +x ~/.local/bin/instruqt
+        fi
+        
+        # Clean up
+        rm instruqt.zip
+        
+        # Add to PATH
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        
+        # Get installed version
+        version=$(~/.local/bin/instruqt version | sed 's/Version: //')
+        echo "version=$version" >> $GITHUB_OUTPUT
+        echo "::notice::Instruqt CLI $version installed"
+
+    - name: Set PATH for cached CLI
+      if: steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        version=$(~/.local/bin/instruqt version | sed 's/Version: //')
+        echo "version=$version" >> $GITHUB_OUTPUT
+        echo "::notice::Instruqt CLI $version restored from cache"

--- a/validate/README.md
+++ b/validate/README.md
@@ -1,0 +1,113 @@
+# Validate Instruqt Lab Action
+
+This action validates Instruqt lab configurations using the `instruqt lab validate` command.
+
+## Prerequisites
+
+This action requires the Instruqt CLI to be installed. Use the `instruqt/cli/setup` action first.
+
+## Inputs
+
+### `path`
+
+**Required** Path to the lab directory or HCL file to validate.
+
+### `fail-on-error`
+
+**Optional** Whether to fail the action on validation errors. Default: `true`.
+
+## Outputs
+
+### `status`
+
+The validation status: `success` or `failed`.
+
+### `output`
+
+The full output from the `instruqt lab validate` command.
+
+## Example usage
+
+### Basic validation
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: instruqt/cli/setup@v1
+  - uses: instruqt/cli/validate@v1
+    with:
+      path: ./lab
+```
+
+### Validate multiple labs
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: instruqt/cli/setup@v1
+  - uses: instruqt/cli/validate@v1
+    with:
+      path: ./lab-1
+  - uses: instruqt/cli/validate@v1
+    with:
+      path: ./lab-2
+```
+
+### Matrix validation
+
+```yaml
+strategy:
+  matrix:
+    lab: [./lab-1, ./lab-2, ./lab-3]
+steps:
+  - uses: actions/checkout@v4
+  - uses: instruqt/cli/setup@v1
+  - uses: instruqt/cli/validate@v1
+    with:
+      path: ${{ matrix.lab }}
+```
+
+### Continue on validation errors
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: instruqt/cli/setup@v1
+  - uses: instruqt/cli/validate@v1
+    with:
+      path: ./lab
+      fail-on-error: false
+  - name: Check validation result
+    if: steps.validate.outputs.status == 'failed'
+    run: echo "Validation failed but continuing..."
+```
+
+## Example Output
+
+### Successful validation
+
+```
+==> Validating lab...
+    [SUCCESS] Lab is valid
+```
+
+### Failed validation
+
+```
+==> Validating lab...
+    [ERROR] Error:
+      Missing required field "description" in task resource "first_task"
+    
+     /path/to/lab/tasks.hcl:5,1-15
+          5 | resource "task" "first_task" {
+    
+    
+    Lab is not valid
+```
+
+## Features
+
+- **Clean output**: Preserves the native `instruqt lab validate` formatting
+- **Job summaries**: Creates collapsible summaries in the GitHub Actions UI
+- **Flexible error handling**: Option to continue on validation failures
+- **Grouped output**: Uses GitHub Actions groups for better readability

--- a/validate/action.yml
+++ b/validate/action.yml
@@ -1,0 +1,92 @@
+name: 'Validate Instruqt Lab'
+description: 'Validate Instruqt lab configurations using instruqt lab validate'
+author: 'Instruqt'
+
+inputs:
+  path:
+    description: 'Path to lab directory or HCL file to validate'
+    required: true
+  fail-on-error:
+    description: 'Whether to fail the action on validation errors'
+    required: false
+    default: 'true'
+
+outputs:
+  status:
+    description: 'Validation status (success or failed)'
+    value: ${{ steps.validate.outputs.status }}
+  output:
+    description: 'Full output from instruqt lab validate'
+    value: ${{ steps.validate.outputs.output }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate lab configuration
+      id: validate
+      shell: bash
+      env:
+        LAB_PATH: ${{ inputs.path }}
+        FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+      run: |
+        set -o pipefail
+        
+        echo "::group::Validating $LAB_PATH"
+        
+        # Run validation and capture output
+        if output=$(instruqt lab validate "$LAB_PATH" 2>&1); then
+          echo "status=success" >> $GITHUB_OUTPUT
+          echo "::notice::Lab validation passed for $LAB_PATH"
+          
+          # Store output
+          {
+            echo "output<<EOF"
+            echo "$output"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+          
+          # Add to job summary
+          echo "## Validation Results for \`$LAB_PATH\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:** Passed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "<details><summary>Output</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "$output" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
+          
+        else
+          exit_code=$?
+          echo "status=failed" >> $GITHUB_OUTPUT
+          
+          # Store output
+          {
+            echo "output<<EOF"
+            echo "$output"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+          
+          # Add to job summary
+          echo "## Validation Results for \`$LAB_PATH\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:** Failed (exit code $exit_code)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Output:" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "$output" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          
+          echo "::endgroup::"
+          
+          if [[ "$FAIL_ON_ERROR" == "true" ]]; then
+            echo "::error::Lab validation failed for $LAB_PATH"
+            exit $exit_code
+          else
+            echo "::warning::Lab validation failed for $LAB_PATH (continuing due to fail-on-error=false)"
+          fi
+        fi
+        
+        echo "::endgroup::"


### PR DESCRIPTION
## Summary
Add two GitHub Actions to provide CI/CD integration for the Instruqt CLI:

- **setup**: Install and cache the Instruqt CLI with cross-platform support
- **validate**: Run `instruqt lab validate` with clean error reporting and job summaries

## Actions Added

### Setup Action (`instruqt/cli/setup@v1`)
- Cross-platform support (Linux, macOS Intel/ARM, Windows)
- CLI caching to improve workflow performance
- Version pinning support (defaults to latest)
- Uses actual GitHub release URLs and proper binary extraction

### Validate Action (`instruqt/cli/validate@v1`)
- Runs `instruqt lab validate` on specified paths
- Preserves native CLI output formatting (already clean and helpful)
- Creates job summaries with collapsible output sections
- Flexible error handling with `fail-on-error` option
- Designed for matrix workflows to validate multiple labs

## Usage
```yaml
- uses: instruqt/cli/setup@v1
- uses: instruqt/cli/validate@v1
  with:
    path: ./path/to/lab
```

## Documentation
- Comprehensive README files for both actions
- Example workflow showing matrix and sequential validation patterns
- Test workflow for CI/CD validation of the actions themselves

## Test Plan
- [ ] Test workflow runs successfully on push/PR
- [ ] Setup action installs CLI on all platforms
- [ ] Validate action correctly handles both success and failure cases
- [ ] Caching works properly across workflow runs
- [ ] Actions work together in matrix strategies